### PR TITLE
transaction mixup fixed

### DIFF
--- a/2016-2017/Lecture 3.tex
+++ b/2016-2017/Lecture 3.tex
@@ -278,7 +278,7 @@ COMMIT;
 		\item Transaction 1 reads the energy and computes the increment, saving it in variable B.
 		\item Transaction 2 reads the energy, writes it and commits.
 		\item Transaction 1 reads the energy again getting a different result.
-		\item \textbf{Problem:} Transaction 2 reads the same value and gets two different results.
+		\item \textbf{Problem:} Transaction 1 reads the same value and gets two different results.
 	}\end{slide}
 	
 \SlideSubSection{Write/Write}


### PR DESCRIPTION
In the example, only T1 does a double read. The problem should therefore be a nonrepeatable read on A during transaction T1.